### PR TITLE
Add configurable client url

### DIFF
--- a/packages/backend/src/api/auth/githubCallback.ts
+++ b/packages/backend/src/api/auth/githubCallback.ts
@@ -7,7 +7,7 @@ const getBaseURL = (loginReferrer?: string): string => {
   return (
     loginReferrer ??
     (process.env.NODE_ENV === "production"
-      ? "https://speedtyper.dev"
+      ? process.env.CLIENT_URL || "https://speedtyper.dev"
       : "http://localhost:3001")
   );
 };

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -61,6 +61,8 @@ export default () => {
               "https://www.speedtyper.dev",
               "https://speedtyper.dev/play",
               "https://www.speedtyper.dev/play",
+              `${process.env.CLIENT_URL}`,
+              `${process.env.CLIENT_URL}/play`,
             ].indexOf(origin) >= 0
           ) {
             return cb(null, true);
@@ -84,6 +86,8 @@ export default () => {
 
   const io = socketIO(server, {
     origins: [
+      `${process.env.CLIENT_URL}`,
+      `${process.env.CLIENT_URL}/play`,
       "https://speedtyper.dev",
       "https://www.speedtyper.dev",
       "https://speedtyper.dev/play",


### PR DESCRIPTION
We can configure client url, but will keep the hardcoded speedtyper.dev for now.