### PR TITLE
Dedupe inner spaces

### DIFF
--- a/packages/back-nest/src/challenges/challenges.module.ts
+++ b/packages/back-nest/src/challenges/challenges.module.ts
@@ -4,6 +4,7 @@ import { GithubConnectorModule } from 'src/connectors/github/github.module';
 import { ProjectsModule } from 'src/projects/projects.module';
 import { CalculateLanguageRunner } from './commands/calculate-language-runner';
 import { ChallengeImportRunner } from './commands/challenge-import-runner';
+import { ReformatChallengesRunner } from './commands/reformat-challenges-runner';
 import { UnsyncedFileImportRunner } from './commands/unsynced-file-import-runner';
 import { Challenge } from './entities/challenge.entity';
 import { UnsyncedFile } from './entities/unsynced-file.entity';
@@ -32,6 +33,7 @@ import { UnsyncedFileService } from './services/unsynced-file.service';
     UnsyncedFileImportRunner,
     UnsyncedFileService,
     CalculateLanguageRunner,
+    ReformatChallengesRunner,
   ],
   exports: [ChallengeService, LiteralService],
 })

--- a/packages/back-nest/src/challenges/commands/reformat-challenges-runner.ts
+++ b/packages/back-nest/src/challenges/commands/reformat-challenges-runner.ts
@@ -1,0 +1,43 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Command, CommandRunner } from 'nest-commander';
+import { Repository } from 'typeorm';
+import { Challenge } from '../entities/challenge.entity';
+import { getFormattedText } from '../services/parser.service';
+
+@Command({
+  name: 'reformat-challenges',
+  arguments: '',
+  options: {},
+})
+export class ReformatChallengesRunner extends CommandRunner {
+  constructor(
+    @InjectRepository(Challenge)
+    private repository: Repository<Challenge>,
+  ) {
+    super();
+  }
+
+  async run(): Promise<void> {
+    const stream = await this.repository
+      .createQueryBuilder('ch')
+      .select('id, content')
+      .stream();
+
+    const pendingUpdates = [];
+    for await (const { id, content } of stream) {
+      if (id !== '77a954ea-ea04-4d12-b86e-fce128b6941f') {
+        continue;
+      }
+      const formattedContent = getFormattedText(content);
+      if (formattedContent !== content) {
+        pendingUpdates.push(
+          this.repository.update({ id }, { content: formattedContent }),
+        );
+      }
+    }
+
+    await Promise.all(pendingUpdates);
+
+    console.log(`Reformatted ${pendingUpdates.length} challenges`);
+  }
+}

--- a/packages/back-nest/src/challenges/services/parser.service.ts
+++ b/packages/back-nest/src/challenges/services/parser.service.ts
@@ -117,7 +117,7 @@ export function removeTrailingSpaces(rawText: string) {
 
 export function dedupeInnerSpaces(rawText: string) {
   const innerSpaces = /(?<=\S+)\s+(?=\S+)/g;
-  const space = " ";
+  const space = ' ';
   return rawText
     .split('\n')
     .map((line) => line.replaceAll(innerSpaces, space))

--- a/packages/back-nest/src/challenges/services/parser.service.ts
+++ b/packages/back-nest/src/challenges/services/parser.service.ts
@@ -115,9 +115,19 @@ export function removeTrailingSpaces(rawText: string) {
     .join('\n');
 }
 
+export function dedupeInnerSpaces(rawText: string) {
+  const innerSpaces = /(?<=\S+)\s+(?=\S+)/g;
+  const space = " ";
+  return rawText
+    .split('\n')
+    .map((line) => line.replaceAll(innerSpaces, space))
+    .join('\n');
+}
+
 export function getFormattedText(rawText: string) {
   rawText = replaceTabsWithSpaces(rawText);
   rawText = removeTrailingSpaces(rawText);
   rawText = removeDuplicateNewLines(rawText);
+  rawText = dedupeInnerSpaces(rawText);
   return rawText;
 }

--- a/packages/back-nest/src/challenges/services/tests/parser.service.spec.ts
+++ b/packages/back-nest/src/challenges/services/tests/parser.service.spec.ts
@@ -49,9 +49,18 @@ const inputWithTrailingSpaces = `func newGRPCProxyCommand() *cobra.Command {
   return lpc
 }`;
 
-const output = `func newGRPCProxyCommand() *cobra.Command {
+const inputWithStructAlignment = `func newGRPCProxyCommand() *cobra.Command {
   lpc := &cobra.Command{
     Use:   "grpc-proxy <subcommand>",
+    Short: "grpc-proxy related command",
+  }
+  lpc.AddCommand(newGRPCProxyStartCommand())
+  return lpc
+}`;
+
+const output = `func newGRPCProxyCommand() *cobra.Command {
+  lpc := &cobra.Command{
+    Use: "grpc-proxy <subcommand>",
     Short: "grpc-proxy related command",
   }
   lpc.AddCommand(newGRPCProxyStartCommand())
@@ -82,6 +91,10 @@ describe('getFormattedText', () => {
   });
   it('should remove empty line with spaces', () => {
     const parsed = getFormattedText(inputWithEmptyLineWithSpaces);
+    expect(parsed).toEqual(output);
+  });
+  it('should dedupe multiple interior spaces', () => {
+    const parsed = getFormattedText(inputWithStructAlignment);
     expect(parsed).toEqual(output);
   });
 });


### PR DESCRIPTION
As discussed in discord, convert a series of spaces in the interior of a line to single space. This removes the weird smashing of the space bar necessary with vertical alignment. For example, 2 fields in a go struct:

```go
struct User {
  Email:    string
  Username: string
}
```

Tests are passing. I need some guidance on how to really test this locally. I tried changing some of the URLs the seeder uses for import as well as changing the postgres column directly but couldn't see confirmation that `getFormattedText` was actually being called.