### PR TITLE
Clearer error if github token is not valid

### DIFF
--- a/packages/back-nest/src/connectors/github/services/github-api.ts
+++ b/packages/back-nest/src/connectors/github/services/github-api.ts
@@ -94,5 +94,10 @@ function getGithubAccessToken(cfg: ConfigService) {
       `GITHUB_ACCESS_TOKEN is missing from environment variables`,
     );
   }
+  if (!token.startsWith('ghp_')) {
+    throw new Error(
+      `GITHUB_ACCESS_TOKEN is not a valid value. It should start with 'ghp_'`,
+    );
+  }
   return token;
 }


### PR DESCRIPTION
Existing code only checks for empty string, but since the default `.env.development` has a placeholder, the script proceeds anyway. Ideally we should fail if github API calls fail but the scripts seem to proceed (although maybe for public repos it's OK if the token is invalid?).