### PR TITLE
Save selected language and load at start

### DIFF
--- a/packages/webapp-next/modules/play2/components/race-settings/LanguageSelector.tsx
+++ b/packages/webapp-next/modules/play2/components/race-settings/LanguageSelector.tsx
@@ -2,16 +2,11 @@ import useSWR from "swr";
 import { Listbox } from "@headlessui/react";
 import { CrossIcon } from "../../../../assets/icons/CrossIcon";
 import { getExperimentalServerUrl } from "../../../../common/utils/getServerUrl";
-import { useSettingsStore } from "../../state/settings-store";
+import { useSettingsStore, LanguageDTO, setLanguage } from "../../state/settings-store";
 import { useGameStore } from "../../state/game-store";
 
-export interface LanguageDTO {
-  language: string;
-  name: string;
-}
-
 const selectProgrammingLanguage = (languageSelected: LanguageDTO | null) => {
-  useSettingsStore.setState((s) => ({ ...s, languageSelected }));
+  setLanguage(languageSelected);
   if (languageSelected) {
     useGameStore.getState().game?.next();
   }

--- a/packages/webapp-next/modules/play2/state/settings-store.ts
+++ b/packages/webapp-next/modules/play2/state/settings-store.ts
@@ -90,8 +90,11 @@ export const setLanguage = (language: LanguageDTO | null) => {
     stored = JSON.stringify(language);
   }
   localStorage.setItem(LANGUAGE_KEY, stored);
-  useSettingsStore.setState((state) => ({ ...state, languageSelected: language }));
-}
+  useSettingsStore.setState((state) => ({
+    ...state,
+    languageSelected: language,
+  }));
+};
 
 export const toggleDefaultRaceIsPublic = () => {
   const booleanStrValue = localStorage.getItem(DEFAULT_RACE_IS_PUBLIC_KEY);

--- a/packages/webapp-next/modules/play2/state/settings-store.ts
+++ b/packages/webapp-next/modules/play2/state/settings-store.ts
@@ -48,7 +48,7 @@ function getInitialLanguageFromLocalStorage(key: string): LanguageDTO | null {
     let languageStr = localStorage.getItem(key) ?? "";
     let lang;
     try {
-      lang = JSON.parse((languageStr));
+      lang = JSON.parse(languageStr);
     } catch (e) {}
     if (!lang?.language || !lang?.name) {
       return null;

--- a/packages/webapp-next/modules/play2/state/settings-store.ts
+++ b/packages/webapp-next/modules/play2/state/settings-store.ts
@@ -1,6 +1,11 @@
 import create from "zustand";
 import { getExperimentalServerUrl } from "../../../common/utils/getServerUrl";
 
+export interface LanguageDTO {
+  language: string;
+  name: string;
+}
+
 export interface SettingsState {
   settingsModalIsOpen: boolean;
   languageModalIsOpen: boolean;
@@ -8,7 +13,7 @@ export interface SettingsState {
   profileModalIsOpen: boolean;
   projectModalIsOpen: boolean;
   publicRacesModalIsOpen: boolean;
-  languageSelected: { language: string; name: string } | null;
+  languageSelected: LanguageDTO | null;
   smoothCaret: boolean;
   syntaxHighlighting: boolean;
   raceIsPublic: boolean;
@@ -20,6 +25,24 @@ const SYNTAX_HIGHLIGHTING_KEY = "syntaxHighlighting";
 const SMOOTH_CARET_KEY = "smoothCaret";
 
 const DEFAULT_RACE_IS_PUBLIC_KEY = "defaultRaceIsPublic2";
+
+const LANGUAGE_KEY = "language";
+
+const LANGUAGES: { [ext: string]: string } = {
+  js: 'JavaScript',
+  ts: 'TypeScript',
+  rs: 'Rust',
+  c: 'C',
+  java: 'Java',
+  cpp: 'C++',
+  go: 'Go',
+  lua: 'Lua',
+  php: 'PHP',
+  py: 'Python',
+  rb: 'Ruby',
+  cs: 'C-Sharp',
+  scala: 'Scala',
+};
 
 function getInitialToggleStateFromLocalStorage(
   key: string,
@@ -34,6 +57,18 @@ function getInitialToggleStateFromLocalStorage(
     return toggleStateStr === "true" ?? false;
   }
   return defaultToggleValue;
+}
+
+function getInitialLanguageFromLocalStorage(key: string): LanguageDTO | null {
+  if (typeof document !== "undefined" && window) {
+    let languageStr = localStorage.getItem(key) ?? "";
+    const lang = {language: languageStr, name: LANGUAGES[languageStr]};
+    if (!lang.language || !lang.name) {
+      return null;
+    }
+    return lang;
+  }
+  return null;
 }
 
 export const useSettingsStore = create<SettingsState>((_set, _get) => ({
@@ -53,7 +88,7 @@ export const useSettingsStore = create<SettingsState>((_set, _get) => ({
     DEFAULT_RACE_IS_PUBLIC_KEY,
     false
   ),
-  languageSelected: null,
+  languageSelected: getInitialLanguageFromLocalStorage(LANGUAGE_KEY),
 }));
 
 export const setCaretType = (caretType: "smooth" | "block") => {
@@ -61,6 +96,11 @@ export const setCaretType = (caretType: "smooth" | "block") => {
   localStorage.setItem(SMOOTH_CARET_KEY, smoothCaret.toString());
   useSettingsStore.setState((state) => ({ ...state, smoothCaret }));
 };
+
+export const setLanguage = (language: LanguageDTO | null) => {
+  localStorage.setItem(LANGUAGE_KEY, language?.language || "");
+  useSettingsStore.setState((state) => ({ ...state, languageSelected: language }));
+}
 
 export const toggleDefaultRaceIsPublic = () => {
   const booleanStrValue = localStorage.getItem(DEFAULT_RACE_IS_PUBLIC_KEY);

--- a/packages/webapp-next/modules/play2/state/settings-store.ts
+++ b/packages/webapp-next/modules/play2/state/settings-store.ts
@@ -28,22 +28,6 @@ const DEFAULT_RACE_IS_PUBLIC_KEY = "defaultRaceIsPublic2";
 
 const LANGUAGE_KEY = "language";
 
-const LANGUAGES: { [ext: string]: string } = {
-  js: 'JavaScript',
-  ts: 'TypeScript',
-  rs: 'Rust',
-  c: 'C',
-  java: 'Java',
-  cpp: 'C++',
-  go: 'Go',
-  lua: 'Lua',
-  php: 'PHP',
-  py: 'Python',
-  rb: 'Ruby',
-  cs: 'C-Sharp',
-  scala: 'Scala',
-};
-
 function getInitialToggleStateFromLocalStorage(
   key: string,
   defaultToggleValue: boolean
@@ -62,8 +46,11 @@ function getInitialToggleStateFromLocalStorage(
 function getInitialLanguageFromLocalStorage(key: string): LanguageDTO | null {
   if (typeof document !== "undefined" && window) {
     let languageStr = localStorage.getItem(key) ?? "";
-    const lang = {language: languageStr, name: LANGUAGES[languageStr]};
-    if (!lang.language || !lang.name) {
+    let lang;
+    try {
+      lang = JSON.parse((languageStr));
+    } catch (e) {}
+    if (!lang?.language || !lang?.name) {
       return null;
     }
     return lang;
@@ -98,7 +85,11 @@ export const setCaretType = (caretType: "smooth" | "block") => {
 };
 
 export const setLanguage = (language: LanguageDTO | null) => {
-  localStorage.setItem(LANGUAGE_KEY, language?.language || "");
+  let stored = "";
+  if (language) {
+    stored = JSON.stringify(language);
+  }
+  localStorage.setItem(LANGUAGE_KEY, stored);
   useSettingsStore.setState((state) => ({ ...state, languageSelected: language }));
 }
 


### PR DESCRIPTION
You may want to extract the `LANGUAGES` object out to a shared place or something but for the purposes of this PR I just duplicated it across frontend and backend packages.