### PR TITLE
Update instructions for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,35 +23,47 @@
 
 ### Backend
 
-Install dependencies:
-```
-make install-backend-dependencies
-```
-Copy over path of env file:
-```
-cp ./packages/back-nest/.env.development ./packages/back-nest/.env
-```
-Start Docker Compose in the background:
-```
-make run-dev-db
-```
-Seed the db with example challenges 
-```
-make run-seed-codesources
-```
+1. Install dependencies:
 
-Run the backend:
-```
-make run-backend-dev
-```
+    ```
+    make install-backend-dependencies
+    ```
+1. Copy over path of env file:
+
+    ```
+    cp ./packages/back-nest/.env.development ./packages/back-nest/.env
+    ```
+
+1. Generate [Github Access Token (classic)](https://github.com/settings/tokens) with `public_repo` permissions and update `GITHUB_ACCESS_TOKEN` variable in `./packages/back-nest/.env` with the token value. It is used to download seed data from GitHub.
+
+1. Start Docker Compose in the background:
+
+    ```
+    make run-dev-db
+    ```
+
+1. Seed the db with example challenges:
+
+    ```
+    make run-seed-codesources
+    ```
+
+1. Run the backend:
+
+    ```
+    make run-backend-dev
+    ```
 
 ### Frontend
 
-Install dependencies:
-```
-make install-webapp-dependencies
-```
-Run the frontend:
-```
-make run-webapp-dev
-```
+1. Install dependencies:
+
+    ```
+    make install-webapp-dependencies
+    ```
+
+1. Run the frontend:
+
+    ```
+    make run-webapp-dev
+    ```

--- a/packages/back-nest/docker-compose.yml
+++ b/packages/back-nest/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       POSTGRES_USERNAME: postgres
       POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: speedtyper
 
   adminer:
     image: adminer


### PR DESCRIPTION
I faced a few issues after going through the instructions in `CONTRIBUTING.md`. The PR addresses the following issues:

1. `make run-seed-codesources` requires a valid Github Access Token to be able to access GitHub data, so it should be added to `.env` file. I added this information to the `CONTRIBUTING.md` file. Also, I converted it to a numbered list to make it clear that obtaining the token is a separate step.
2. By default `make run-seed-codesources` will fail even with the valid token, because when the postgres is started no `speedtyper` database was created. Fixed it in docker-compose.yml.