### PR TITLE
Limit the words per minute allowed

### DIFF
--- a/packages/back-nest/src/results/services/result-calculation.service.ts
+++ b/packages/back-nest/src/results/services/result-calculation.service.ts
@@ -17,6 +17,16 @@ export class ResultCalculationService {
     const strippedCode = Challenge.getStrippedCode(code);
     const cps = strippedCode.length / timeSeconds;
     const cpm = cps * 60;
+    const words = strippedCode.trim().split(' ');
+    if (words.length === 0) { // Avoid division by zero
+      return 0;
+    }
+    const totalWordLength = words.reduce((sum, word) => sum + word.length, 0);
+    const avgWordLength = totalWordLength / words.length;
+    const wpm = cpm / avgWordLength;
+    if (wpm > 300) { // Abitrary value, change as needed, if cpm is greater they are most likely using an automation program
+      return 0; // Simply give them no score 
+    }
     return Math.floor(cpm);
   }
 


### PR DESCRIPTION
I create a simple python script to type out a challenge for me and realized that I was able to type over 1000 words per minute with, I add a quick "half assed" fix for it. In the getCPM method in ResultCalulationService I made it so it just returns 0 if the words per minute is greater than 300, there may be a better implementation for this due to the fact I am still learning the codebase.